### PR TITLE
Fix shorthand flags not get recognised

### DIFF
--- a/cmd/eli/createCommand.go
+++ b/cmd/eli/createCommand.go
@@ -25,7 +25,8 @@ var createCommand = cli.Command{
 `,
 	Flags: []cli.Flag{
 		cli.StringSliceFlag{
-			Name:  "file,f",
+			Name: "file, f",
+
 			Usage: "Filename, directory, or URL to files to use to create the resource",
 		},
 		cli.StringSliceFlag{
@@ -35,12 +36,12 @@ var createCommand = cli.Command{
 	},
 	Action: func(clicontext *cli.Context) (err error) {
 		pods := []*pods.Pod{}
-		if clicontext.IsSet("file") && len(clicontext.StringSlice("file")) > 0 {
+		if len(clicontext.StringSlice("file")) > 0 {
 			pods, err = resolve.Pods(clicontext.StringSlice("file"))
 			if err != nil {
 				return err
 			}
-		} else if clicontext.IsSet("image") && len(clicontext.StringSlice("image")) > 0 {
+		} else if len(clicontext.StringSlice("image")) > 0 {
 			pods = resolve.BuildPods(clicontext.StringSlice("image"))
 		} else {
 			return errors.New("You need to give either --file or --image flag")

--- a/cmd/eli/runCommand.go
+++ b/cmd/eli/runCommand.go
@@ -165,7 +165,7 @@ var runCommand = cli.Command{
 				cmd.MustParseBindFlag(fmt.Sprintf("/var/lib/volumes/%s:%s:rw,rshared", name, syncTargetPath)),
 			))
 
-			if !clicontext.IsSet("workdir") {
+			if !clicontext.IsSet("workdir") && !clicontext.IsSet("w") {
 				opts = append(opts, api.WithWorkingDir(syncTargetPath))
 			}
 		}

--- a/cmd/eliotd/main.go
+++ b/cmd/eliotd/main.go
@@ -60,6 +60,11 @@ func main() {
 			Usage:  "Enable discover GRPC server over zeroconf",
 			EnvVar: "ELIOT_DISCOVERY",
 		},
+		cli.StringFlag{
+			Name:   "labels",
+			Usage:  "Comma separated list of device labels. E.g. --labels device=rpi3,location=home,environment=testing",
+			EnvVar: "ELIOT_LABELS",
+		},
 	}, cmd.GlobalFlags...)
 	app.Version = version.VERSION
 	app.Before = cmd.GlobalBefore


### PR DESCRIPTION
Command `eli create -f somefile.yml`, returned error that
must define either --file or --image. This because the
clicontext.IsSet() were returning false if using shorthand aliases.
There is fix coming in urfave/cli v2.0:
https://github.com/urfave/cli/issues/294

But actually we don't need to use that in our use cases so removed
the extra IsSet checks.