### PR TITLE
Test binary and containers start in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
             VERSION=$(git describe --tags --always --dirty)
             gox -osarch="darwin/amd64 linux/amd64 linux/arm64" -ldflags "-X github.com/ernoaapa/eliot/pkg/version.VERSION=${VERSION}" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" ./cmd/...
 
+      - run:
+          name: Verify binaries
+          command: |
+            ./dist/eliotd_linux_amd64 -h
+
       - save_cache:
           key: binaries-{{ .Revision }}
           paths:

--- a/.circleci/scripts/docker-build.sh
+++ b/.circleci/scripts/docker-build.sh
@@ -27,6 +27,14 @@ for bin in eliotd; do
     echo "----------------Dockerfile end----------------------"
 
     docker build -t ${tag} -f .dockerfile-${arch} .
+    
+    # Test spin up amd64 container because running in circleCI
+    if [ $arch == "amd64" ]; then
+      echo "Test running the container by printing help text"
+      docker run -it ${tag} -h
+    fi
+    
+    echo "Push image to repository"
     docker push ${tag}
   done
 


### PR DESCRIPTION
To verify that the container contains the binary and works, added
test run with Docker to print out the help text.