### PR TITLE
 Run build with CGO_ENABLED=0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,15 @@ jobs:
       - run: "! go fmt -l pkg cmd 2>&1 | read"
       - run: go vet ./...
       - run: go test -v ./...
-  
+
   build:
     docker:
       - image: circleci/golang:1.9
     working_directory: /go/src/github.com/ernoaapa/eliot
     steps:
       - checkout
+
+      - setup_remote_docker
 
       - run:
           name: Install tools
@@ -32,6 +34,10 @@ jobs:
           name: Verify binaries
           command: |
             ./dist/eliotd_linux_amd64 -h
+
+      - run:
+          name: Build images
+          command: ./.circleci/scripts/docker-build.sh
 
       - save_cache:
           key: binaries-{{ .Revision }}
@@ -79,6 +85,10 @@ jobs:
       - run:
           name: Build images
           command: ./.circleci/scripts/docker-build.sh
+
+      - run:
+          name: Push images
+          command: ./.circleci/scripts/docker-push.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
       - run:
           name: Build binaries
           command: |
-            VERSION=$(git describe --tags --always --dirty)
+            export VERSION=$(git describe --tags --always --dirty)
+            export CGO_ENABLED=0
             gox -osarch="darwin/amd64 linux/amd64 linux/arm64" -ldflags "-X github.com/ernoaapa/eliot/pkg/version.VERSION=${VERSION}" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" ./cmd/...
 
       - run:

--- a/.circleci/scripts/docker-build.sh
+++ b/.circleci/scripts/docker-build.sh
@@ -33,16 +33,5 @@ for bin in eliotd; do
       echo "Test running the container by printing help text"
       docker run -it ${tag} -h
     fi
-    
-    echo "Push image to repository"
-    docker push ${tag}
   done
-
-	manifest-tool \
-		--username ${DOCKER_USER} \
-		--password ${DOCKER_PASS} \
-		push from-args \
-    --platforms $PLATFORMS \
-    --template ${image}:${GIT_HASH}-ARCH \
-    --target ${image}:${GIT_HASH}
 done

--- a/.circleci/scripts/docker-build.sh
+++ b/.circleci/scripts/docker-build.sh
@@ -13,6 +13,18 @@ for bin in eliotd; do
     arch="${osarch#*/}"
     echo "Building container for: $bin $os $arch"
 
+    if [ ! -f "./dist/${bin}_${os}_${arch}" ]; then
+      echo "Missing binary dist/${bin}_${os}_${arch}!"
+      exit 1
+    else
+      chmod +x "./dist/${bin}_${os}_${arch}"
+
+      if [ $arch == "amd64" ]; then
+        echo "Test running the binary by printing help text"
+        ./dist/${bin}_${os}_${arch} -h
+      fi
+    fi
+
     sed \
 	    -e "s|ARG_BIN|${bin}|g" \
 			-e "s|ARG_OS|${os}|g" \

--- a/.circleci/scripts/docker-push.sh
+++ b/.circleci/scripts/docker-push.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+REGISTRY=ernoaapa
+PLATFORMS="linux/amd64,linux/arm64"
+GIT_HASH=$(git describe --tags --always --dirty)
+
+
+for bin in eliotd; do
+  image="${REGISTRY}/${bin}"
+  
+  for osarch in ${PLATFORMS//,/ }; do
+    os="${osarch%%/*}"
+    arch="${osarch#*/}"
+    echo "Pushing container for: $bin $os $arch, tag: ${tag}"
+
+    docker push ${tag}
+  done
+
+	manifest-tool \
+		--username ${DOCKER_USER} \
+		--password ${DOCKER_PASS} \
+		push from-args \
+    --platforms $PLATFORMS \
+    --template ${image}:${GIT_HASH}-ARCH \
+    --target ${image}:${GIT_HASH}
+done


### PR DESCRIPTION
Previously eliotd Docker image what we produced were failing to
following error in Linuxkit:
```
standard_init_linux.go:195: exec user process caused "no such file or directory"
```

After testing out the binaries in alpine container, got error:
`sh: /eliotd: not found`

Found similar issue here:
https://github.com/gliderlabs/docker-alpine#78

Fixed by compiling binaries with CGO_ENABLED=0.
Also added container text execution to Circleci to verify
that container works.