### PR TITLE
Split 'eli create --image' to 'eli create pod' command

### DIFF
--- a/cmd/eli/createCommand.go
+++ b/cmd/eli/createCommand.go
@@ -29,10 +29,9 @@ var createCommand = cli.Command{
 
 			Usage: "Filename, directory, or URL to files to use to create the resource",
 		},
-		cli.StringSliceFlag{
-			Name:  "image",
-			Usage: "The container image to run",
-		},
+	},
+	Subcommands: []cli.Command{
+		createPodCommand,
 	},
 	Action: func(clicontext *cli.Context) (err error) {
 		pods := []*pods.Pod{}
@@ -41,10 +40,8 @@ var createCommand = cli.Command{
 			if err != nil {
 				return err
 			}
-		} else if len(clicontext.StringSlice("image")) > 0 {
-			pods = resolve.BuildPods(clicontext.StringSlice("image"))
 		} else {
-			return errors.New("You need to give either --file or --image flag")
+			return errors.New("You need to give --file flag")
 		}
 
 		config := cmd.GetConfigProvider(clicontext)

--- a/cmd/eli/createPodCommand.go
+++ b/cmd/eli/createPodCommand.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+
+	"github.com/ernoaapa/eliot/cmd"
+	pods "github.com/ernoaapa/eliot/pkg/api/services/pods/v1"
+	"github.com/ernoaapa/eliot/pkg/cmd/log"
+	"github.com/ernoaapa/eliot/pkg/printers"
+	"github.com/ernoaapa/eliot/pkg/progress"
+	"github.com/ernoaapa/eliot/pkg/resolve"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var createPodCommand = cli.Command{
+	Name:        "pod",
+	HelpName:    "pod",
+	Usage:       "Create new pod",
+	Description: "With create pod command, you can create new pod into the device",
+	UsageText: `eli create pod [options] <NAME>
+
+	 # Create new pod 'my-pod' and create single container
+	 eli create pod --image docker.io/arm64v8/alpine:latest my-pod
+`,
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  "image",
+			Usage: "The container image to run. You can pass as many images you want",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		var (
+			images = clicontext.StringSlice("image")
+			name   = clicontext.Args().First()
+		)
+
+		if name == "" {
+			return errors.New("You need to give name for the pod")
+		}
+
+		var pod *pods.Pod
+		if len(images) > 0 {
+			pod = resolve.BuildPod(name, images)
+		} else {
+			return errors.New("You need to give at least one --image flag")
+		}
+
+		config := cmd.GetConfigProvider(clicontext)
+		client := cmd.GetClient(config)
+
+		logs := map[string]*log.Line{}
+		progressc := make(chan []*progress.ImageFetch)
+
+		go func() {
+			for fetches := range progressc {
+				for _, fetch := range fetches {
+					if _, ok := logs[fetch.Image]; !ok {
+						logs[fetch.Image] = log.NewLine().Loadingf("Download %s", fetch.Image)
+					}
+
+					if fetch.IsDone() {
+						if fetch.Failed {
+							logs[fetch.Image].Errorf("Failed %s", fetch.Image)
+						} else {
+							logs[fetch.Image].Donef("Downloaded %s", fetch.Image)
+						}
+					} else {
+						current, total := fetch.GetProgress()
+						logs[fetch.Image].WithProgress(current, total)
+					}
+				}
+			}
+		}()
+		err := client.CreatePod(progressc, pod)
+		close(progressc)
+		if err != nil {
+			return err
+		}
+
+		result, err := client.StartPod(pod.Metadata.Name)
+		if err != nil {
+			return err
+		}
+
+		writer := printers.GetNewTabWriter(os.Stdout)
+		defer writer.Flush()
+		printer := cmd.GetPrinter(clicontext)
+
+		if err := printer.PrintPodDetails(result, writer); err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/pkg/utils/fqin.go
+++ b/pkg/utils/fqin.go
@@ -47,7 +47,9 @@ func ExpandToFQIN(source string) string {
 // E.g. docker.io/eaapa/hello-world:latest -> hello-world
 func GetFQINImage(fqin string) string {
 	parts := strings.SplitN(fqin, "/", 3)
-	return parts[2]
+	image := parts[2]
+	imageParts := strings.SplitN(image, ":", 2)
+	return imageParts[0]
 }
 
 // GetFQINUsername returns username part from FQIN

--- a/pkg/utils/fqin_test.go
+++ b/pkg/utils/fqin_test.go
@@ -16,8 +16,10 @@ func TestExpandToFQIN(t *testing.T) {
 
 func TestGetFQINImage(t *testing.T) {
 	assert.Equal(t, "hello-world", GetFQINImage("docker.io/eaapa/hello-world"))
+	assert.Equal(t, "hello-world", GetFQINImage("docker.io/eaapa/hello-world:latest"))
 }
 
 func TestGetFQINUsername(t *testing.T) {
 	assert.Equal(t, "eaapa", GetFQINUsername("docker.io/eaapa/hello-world"))
+	assert.Equal(t, "eaapa", GetFQINUsername("docker.io/eaapa/hello-world:latest"))
 }


### PR DESCRIPTION
Previously you were able to create pod with command
`eli create --image`. This felt unconsistent with other commands so
splitted the command so that now there's two commands:
`eli create --file` to create all resources in the file and
`eli create pod --image` which creates single pod with given container.
  