### PR TITLE
Split 'run' command to 'run' and 'up'

### DIFF
--- a/.eliot.yml
+++ b/.eliot.yml
@@ -1,5 +1,5 @@
-sync:
-  target: /go/src/github.com/ernoaapa/eliot
+syncs:
+  - .:/go/src/github.com/ernoaapa/eliot
 binds:
   - /containers:/containers
   - /var/lib/volumes:/var/lib/volumes

--- a/cmd/eli/main.go
+++ b/cmd/eli/main.go
@@ -61,6 +61,7 @@ func main() {
 		deleteCommand,
 		attachCommand,
 		runCommand,
+		upCommand,
 		execCommand,
 		createCommand,
 		configCommand,

--- a/cmd/eli/runCommand.go
+++ b/cmd/eli/runCommand.go
@@ -67,7 +67,6 @@ var runCommand = cli.Command{
 		},
 	},
 	Action: func(clicontext *cli.Context) (err error) {
-
 		var (
 			name    = clicontext.String("name")
 			image   = clicontext.Args().First()
@@ -75,8 +74,8 @@ var runCommand = cli.Command{
 			tty     = clicontext.Bool("tty")
 			env     = clicontext.StringSlice("env")
 			workdir = clicontext.String("workdir")
-			mounts  = cmd.GetMounts(clicontext)
-			binds   = cmd.GetBinds(clicontext)
+			mounts  = cmd.MustParseMounts(clicontext.StringSlice("mount"))
+			binds   = cmd.MustParseBinds(clicontext.StringSlice("bind"))
 			args    = cmd.DropDoubleDash(clicontext.Args().Tail())
 
 			stdin  = os.Stdin

--- a/cmd/eli/runCommand.go
+++ b/cmd/eli/runCommand.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/ernoaapa/eliot/cmd"
 	"github.com/ernoaapa/eliot/pkg/api"
@@ -14,12 +13,9 @@ import (
 	containers "github.com/ernoaapa/eliot/pkg/api/services/containers/v1"
 	pods "github.com/ernoaapa/eliot/pkg/api/services/pods/v1"
 	"github.com/ernoaapa/eliot/pkg/cmd/ui"
-	"github.com/ernoaapa/eliot/pkg/config"
 	"github.com/ernoaapa/eliot/pkg/model"
-	"github.com/ernoaapa/eliot/pkg/printers"
 	"github.com/ernoaapa/eliot/pkg/progress"
 	"github.com/ernoaapa/eliot/pkg/resolve"
-	"github.com/ernoaapa/eliot/pkg/sync"
 	"github.com/ernoaapa/eliot/pkg/term"
 	"github.com/ernoaapa/eliot/pkg/utils"
 	"github.com/pkg/errors"
@@ -29,34 +25,17 @@ import (
 var runCommand = cli.Command{
 	Name:        "run",
 	HelpName:    "run",
-	Usage:       "Start container in the device",
-	Description: "With run command, you can start new containers in the device",
-	UsageText: `eli run [options] -- <command>
+	Usage:       "Run commmand in new container in the device",
+	Description: "With run command, you can run command in a new container in the device",
+	UsageText: `eli run [options] <image> -- <command> <args>
 
-	 # Run code in current directory in the device
-	 eli run
-
-	 # Run 'build.sh' command in device with files in current directory
-	 eli run -- ./build.sh
-	 
-	 # Run container image in the container
-	 eli run --image docker.io/eaapa/hello-world:latest
-
-	 # Run container with name in the device
-	 eli run --image docker.io/eaapa/hello-world:latest --name my-pod
+	 # Run shell session in 'eaapa/hello-world' container
+	 eli run -i -t eaapa/hello-world -- /bin/sh
 `,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "name",
 			Usage: "Name for the pod (default: current directory name)",
-		},
-		cli.StringFlag{
-			Name:  "image",
-			Usage: "The container image to start (default: resolve image based on project structure)",
-		},
-		cli.BoolFlag{
-			Name:  "detach, d",
-			Usage: "Run container in background and print container information (default: false)",
 		},
 		cli.StringSliceFlag{
 			Name:  "mount",
@@ -82,15 +61,6 @@ var runCommand = cli.Command{
 			Name:  "stdin, i",
 			Usage: "Keep stdin open on the container(s) in the pod, even if nothing is attached (default: true)",
 		},
-		cli.BoolFlag{
-			Name:  "no-sync",
-			Usage: "Do not sync any directory to the container (default: false)",
-		},
-		cli.StringSliceFlag{
-			Name:  "sync",
-			Usage: "Directory to sync to the target container (default: current directory)",
-			Value: &cli.StringSlice{"."},
-		},
 		cli.StringFlag{
 			Name:  "workdir, w",
 			Usage: "Working directory inside the container",
@@ -99,24 +69,24 @@ var runCommand = cli.Command{
 	Action: func(clicontext *cli.Context) (err error) {
 
 		var (
-			projectConfig = config.ReadProjectConfig("./.eliot.yml")
-			name          = cmd.First(clicontext.String("name"), projectConfig.Name)
-			image         = cmd.First(clicontext.String("image"), projectConfig.Image)
-			detach        = clicontext.Bool("detach")
-			rm            = clicontext.Bool("rm")
-			tty           = clicontext.Bool("tty")
-			env           = projectConfig.EnvWith(clicontext.StringSlice("env"))
-			workdir       = clicontext.String("workdir")
-			noSync        = clicontext.Bool("no-sync")
-			syncDirs      = clicontext.StringSlice("sync")
-			mounts        = cmd.GetMounts(clicontext)
-			binds         = cmd.GetBinds(clicontext, projectConfig.Binds...)
-			args          = clicontext.Args()
+			name    = clicontext.String("name")
+			image   = clicontext.Args().First()
+			rm      = clicontext.Bool("rm")
+			tty     = clicontext.Bool("tty")
+			env     = clicontext.StringSlice("env")
+			workdir = clicontext.String("workdir")
+			mounts  = cmd.GetMounts(clicontext)
+			binds   = cmd.GetBinds(clicontext)
+			args    = cmd.DropDoubleDash(clicontext.Args().Tail())
 
 			stdin  = os.Stdin
 			stdout = os.Stdout
 			stderr = os.Stderr
 		)
+
+		if clicontext.IsSet("detach") || clicontext.IsSet("d") {
+			return errors.New("Detach not available. If you want to run container in background, use 'eli create pod' -command")
+		}
 
 		conf := cmd.GetConfigProvider(clicontext)
 		client := cmd.GetClient(conf)
@@ -143,35 +113,9 @@ var runCommand = cli.Command{
 			name = filepath.Base(cmd.GetCurrentDirectory())
 		}
 
-		if detach && rm {
-			return fmt.Errorf("You cannot use --detach flag with --rm, it would remove right away after container started")
-		}
-
 		for _, variable := range env {
 			if !model.IsValidEnvKeyValuePair(variable) {
 				return fmt.Errorf("Invalid --env value [%s], must be in format KEY=value. E.g. --env FOO=bar", variable)
-			}
-		}
-
-		opts := []api.PodOpts{}
-
-		if !noSync {
-			syncTargetPath := projectConfig.Sync.Target
-
-			opts = append(opts, api.WithContainer(&containers.Container{
-				Name:  fmt.Sprintf("rsync-%s", name),
-				Image: utils.ExpandToFQIN(projectConfig.Sync.Image),
-				Env: []string{
-					fmt.Sprintf("VOLUME=%s", syncTargetPath),
-				},
-			}))
-
-			opts = append(opts, api.WithSharedMount(
-				cmd.MustParseBindFlag(fmt.Sprintf("/var/lib/volumes/%s:%s:rw,rshared", name, syncTargetPath)),
-			))
-
-			if !clicontext.IsSet("workdir") && !clicontext.IsSet("w") {
-				opts = append(opts, api.WithWorkingDir(syncTargetPath))
 			}
 		}
 
@@ -218,16 +162,15 @@ var runCommand = cli.Command{
 					}
 				}
 			}
+
+			for image, line := range lines {
+				line.Donef("Downloaded %s", image)
+			}
 		}()
-		createErr := client.CreatePod(progressc, pod, opts...)
+		createErr := client.CreatePod(progressc, pod)
 		close(progressc)
 		if createErr != nil {
 			return errors.Wrapf(createErr, "Error in creating pod")
-		}
-
-		result, err := client.StartPod(name)
-		if err != nil {
-			return errors.Wrapf(err, "Error in starting pod")
 		}
 
 		if rm {
@@ -242,24 +185,14 @@ var runCommand = cli.Command{
 			}()
 		}
 
-		if detach {
-			writer := printers.GetNewTabWriter(os.Stdout)
-			defer writer.Flush()
-			printer := cmd.GetPrinter(clicontext)
-			return printer.PrintPodDetails(result, writer)
+		result, err := client.StartPod(name)
+		if err != nil {
+			return errors.Wrapf(err, "Error in starting pod")
 		}
 
 		attachContainerID, err := findRunningContainerID(result, name)
 		if err != nil {
 			return errors.Wrapf(err, "Cannot attach to container")
-		}
-
-		hooks := []api.AttachHooks{}
-		if !noSync {
-			hooks = append(hooks, func(endpoint config.Endpoint, done <-chan struct{}) {
-				destination := fmt.Sprintf("rsync://%s:%d/volume", endpoint.GetHost(), 873)
-				sync.StartRsync(done, syncDirs, destination, 1*time.Second)
-			})
 		}
 
 		term := term.TTY{
@@ -281,7 +214,7 @@ var runCommand = cli.Command{
 		defer ui.Start()
 
 		return term.Safe(func() error {
-			return client.Attach(attachContainerID, api.NewAttachIO(term.In, term.Out, stderr), hooks...)
+			return client.Attach(attachContainerID, api.NewAttachIO(term.In, term.Out, stderr))
 		})
 	},
 }

--- a/cmd/eli/upCommand.go
+++ b/cmd/eli/upCommand.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ernoaapa/eliot/cmd"
+	"github.com/ernoaapa/eliot/pkg/api"
+	"github.com/ernoaapa/eliot/pkg/api/core"
+	containers "github.com/ernoaapa/eliot/pkg/api/services/containers/v1"
+	pods "github.com/ernoaapa/eliot/pkg/api/services/pods/v1"
+	"github.com/ernoaapa/eliot/pkg/cmd/ui"
+	"github.com/ernoaapa/eliot/pkg/config"
+	"github.com/ernoaapa/eliot/pkg/model"
+	"github.com/ernoaapa/eliot/pkg/progress"
+	"github.com/ernoaapa/eliot/pkg/resolve"
+	"github.com/ernoaapa/eliot/pkg/sync"
+	"github.com/ernoaapa/eliot/pkg/term"
+	"github.com/ernoaapa/eliot/pkg/utils"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var upCommand = cli.Command{
+	Name:        "up",
+	HelpName:    "up",
+	Usage:       "Start development session in the device",
+	Description: "With up command, you can start new development session in the device",
+	UsageText: `eli up [options] -- <command>
+
+	 # Run code in current directory in the device
+	 eli up
+
+	 # Run 'build.sh' command in device with files in current directory
+	 eli up -- ./build.sh
+	 
+	 # Run container image in the container
+	 eli up --image docker.io/eaapa/hello-world:latest
+
+	 # Run container with name in the device
+	 eli up --image docker.io/eaapa/hello-world:latest --name my-pod
+`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "name",
+			Usage: "Name for the pod (default: current directory name)",
+		},
+		cli.StringFlag{
+			Name:  "image",
+			Usage: "The container image to start (default: resolve image based on project structure)",
+		},
+		cli.StringSliceFlag{
+			Name:  "mount",
+			Usage: "Attach a filesystem mount to the container",
+		},
+		cli.StringSliceFlag{
+			Name:  "bind",
+			Usage: "Bind a directory in host to the container. Format: /source:/target:options, E.g. /var:/var:rshared",
+		},
+		cli.StringSliceFlag{
+			Name:  "env, e",
+			Usage: "Set environment variable into the container. E.g. --env FOO=bar",
+		},
+		cli.BoolTFlag{
+			Name:  "rm",
+			Usage: "Automatically remove the container when it exits (default: true)",
+		},
+		cli.BoolTFlag{
+			Name:  "tty, t",
+			Usage: "Allocate TTY for each container in the pod (default: true)",
+		},
+		cli.BoolTFlag{
+			Name:  "stdin, i",
+			Usage: "Keep stdin open on the container(s) in the pod, even if nothing is attached (default: true)",
+		},
+		cli.StringSliceFlag{
+			Name:  "sync",
+			Usage: "Directory to sync to the target container (default: current directory)",
+		},
+		cli.StringFlag{
+			Name:  "workdir, w",
+			Usage: "Working directory inside the container",
+		},
+	},
+	Action: func(clicontext *cli.Context) (err error) {
+
+		var (
+			projectConfig = config.ReadProjectConfig("./.eliot.yml")
+			name          = cmd.First(clicontext.String("name"), projectConfig.Name, filepath.Base(cmd.GetCurrentDirectory()))
+			image         = cmd.First(clicontext.String("image"), projectConfig.Image)
+			rm            = clicontext.Bool("rm")
+			tty           = clicontext.Bool("tty")
+			env           = projectConfig.EnvWith(clicontext.StringSlice("env"))
+			workdir       = cmd.First(clicontext.String("workdir"), projectConfig.WorkDir)
+			syncs         = cmd.MustParseSyncs(append(projectConfig.Syncs, clicontext.StringSlice("sync")...))
+			mounts        = cmd.MustParseMounts(append(projectConfig.Mounts, clicontext.StringSlice("mount")...))
+			binds         = cmd.MustParseBinds(append(projectConfig.Binds, clicontext.StringSlice("bind")...))
+			args          = cmd.DropDoubleDash(clicontext.Args())
+
+			stdin  = os.Stdin
+			stdout = os.Stdout
+			stderr = os.Stderr
+		)
+
+		if clicontext.IsSet("detach") || clicontext.IsSet("d") {
+			return errors.New("Detach not available. If you want to run container in background, use 'eli create pod' -command")
+		}
+
+		conf := cmd.GetConfigProvider(clicontext)
+		client := cmd.GetClient(conf)
+
+		if image == "" {
+			log := ui.NewLine().Loading("Resolve image for the project...")
+			info, err := client.GetInfo()
+			if err != nil {
+				log.Fatalf("Unable to resolve image for the project. Failed to get target device architecture: %s", err)
+			}
+
+			var projectType string
+			projectType, image, err = resolve.Image(info.Arch, cmd.GetCurrentDirectory())
+			if err != nil {
+				log.Fatal("Unable to automatically resolve image for the project. You must define target container image with --image option")
+			}
+			log.Donef("Detected %s project, use image: %s (arch %s)", projectType, image, info.Arch)
+		}
+
+		image = utils.ExpandToFQIN(image)
+
+		for _, variable := range env {
+			if !model.IsValidEnvKeyValuePair(variable) {
+				return fmt.Errorf("Invalid --env value [%s], must be in format KEY=value. E.g. --env FOO=bar", variable)
+			}
+		}
+
+		opts := []api.PodOpts{}
+
+		if len(syncs) > 0 && projectConfig.SyncContainer != nil {
+			syncDestinations := []string{}
+			mounts := []*containers.Mount{}
+
+			for _, sync := range syncs {
+				syncDestinations = append(syncDestinations, sync.Destination)
+				mounts = append(mounts, cmd.MustParseBindFlag(fmt.Sprintf("/var/lib/volumes/%s/%s:%s:rw,rshared", name, strings.Replace(sync.Destination, "/", "_", -1), sync.Destination)))
+			}
+
+			projectConfig.SyncContainer.Env = append(projectConfig.SyncContainer.Env, fmt.Sprintf("VOLUMES=%s", strings.Join(syncDestinations, " ")))
+
+			opts = append(opts, api.WithContainer(projectConfig.SyncContainer))
+
+			opts = append(opts, api.WithSharedMount(mounts...))
+
+			if workdir == "" && len(syncDestinations) == 1 {
+				opts = append(opts, api.WithWorkingDir(syncDestinations[0]))
+			}
+		}
+
+		pod := &pods.Pod{
+			Metadata: &core.ResourceMetadata{
+				Name:      name,
+				Namespace: conf.GetNamespace(),
+			},
+			Spec: &pods.PodSpec{
+				HostNetwork: true,
+				Containers: []*containers.Container{
+					&containers.Container{
+						Name:       name,
+						Image:      image,
+						Tty:        tty,
+						Args:       args,
+						Env:        env,
+						WorkingDir: workdir,
+						Mounts:     append(mounts, binds...),
+					},
+				},
+			},
+		}
+
+		logs := map[string]ui.Line{}
+		progressc := make(chan []*progress.ImageFetch)
+
+		go func() {
+			for fetches := range progressc {
+				for _, fetch := range fetches {
+					if _, ok := logs[fetch.Image]; !ok {
+						logs[fetch.Image] = ui.NewLine().Loadingf("Download %s", fetch.Image)
+					}
+
+					if fetch.IsDone() {
+						if fetch.Failed {
+							logs[fetch.Image].Errorf("Failed %s", fetch.Image)
+						} else {
+							logs[fetch.Image].Donef("Downloaded %s", fetch.Image)
+						}
+					} else {
+						current, total := fetch.GetProgress()
+						logs[fetch.Image].WithProgress(current, total)
+					}
+				}
+			}
+		}()
+		createErr := client.CreatePod(progressc, pod, opts...)
+		close(progressc)
+		if createErr != nil {
+			return errors.Wrapf(createErr, "Error in creating pod")
+		}
+
+		result, err := client.StartPod(name)
+		if err != nil {
+			return errors.Wrapf(err, "Error in starting pod")
+		}
+
+		if rm {
+			defer func() {
+				log := ui.NewLine().Loadingf("Delete pod %s", pod.Metadata.Name)
+				_, err := client.DeletePod(pod)
+				if err != nil {
+					log.Errorf("Error while deleting pod [%s]: %s", pod.Metadata.Name, err)
+				} else {
+					log.Donef("Deleted pod [%s]", pod.Metadata.Name)
+				}
+			}()
+		}
+
+		attachContainerID, err := findRunningContainerID(result, name)
+		if err != nil {
+			return errors.Wrapf(err, "Cannot attach to container")
+		}
+
+		hooks := []api.AttachHooks{}
+		if len(syncs) > 0 {
+			hooks = append(hooks, func(endpoint config.Endpoint, done <-chan struct{}) {
+				sync.StartRsync(done, endpoint.GetHost(), 873, syncs, 1*time.Second)
+			})
+		}
+
+		term := term.TTY{
+			Out: stdout,
+		}
+
+		if clicontext.Bool("stdin") {
+			term.In = stdin
+			term.Raw = true
+		} else {
+			sigc := cmd.ForwardAllSignals(func(signal syscall.Signal) error {
+				return client.Signal(attachContainerID, signal)
+			})
+			defer stopCatch(sigc)
+		}
+
+		// Stop updating ui lines, let the std piping take the terminal
+		ui.Stop()
+		defer ui.Start()
+
+		return term.Safe(func() error {
+			return client.Attach(attachContainerID, api.NewAttachIO(term.In, term.Out, stderr), hooks...)
+		})
+	},
+}

--- a/pkg/api/pod_opts.go
+++ b/pkg/api/pod_opts.go
@@ -8,10 +8,10 @@ import (
 )
 
 // WithSharedMount adds mount point to each container
-func WithSharedMount(mount *containers.Mount) PodOpts {
+func WithSharedMount(mounts ...*containers.Mount) PodOpts {
 	return func(pod *pods.Pod) error {
 		for _, container := range pod.Spec.Containers {
-			container.Mounts = append(container.Mounts, mount)
+			container.Mounts = append(container.Mounts, mounts...)
 		}
 		return nil
 	}

--- a/pkg/config/project.go
+++ b/pkg/config/project.go
@@ -2,52 +2,67 @@ package config
 
 import (
 	"io/ioutil"
-	"log"
+
+	containers "github.com/ernoaapa/eliot/pkg/api/services/containers/v1"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ernoaapa/eliot/pkg/fs"
-	"github.com/ghodss/yaml"
+	"github.com/ernoaapa/eliot/pkg/model"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 // ProjectConfig represents configuration in project directory
 type ProjectConfig struct {
-	path  string
-	Name  string     `yaml:"name"`
-	Image string     `yaml:"image"`
-	Env   []string   `yaml:"env"`
-	Binds []string   `yaml:"binds"`
-	Sync  SyncConfig `yaml:"sync"`
-}
+	path    string
+	Name    string   `yaml:"name,omitempty"`
+	Image   string   `yaml:"image,omitempty"`
+	Command []string `yaml:"command,omitempty"`
+	Env     []string `yaml:"env,omitempty"`
+	Binds   []string `yaml:"binds,omitempty"`
+	Mounts  []string `yaml:"mounts,omitempty"`
+	WorkDir string   `yaml:"workdir,omitempty"`
 
-// SyncConfig represents sync related configurations
-type SyncConfig struct {
-	Image  string `yaml:"image"`
-	Target string `yaml:"target"`
+	SyncContainer *containers.Container `yaml:"syncContainer,omitempty"`
+	Syncs         []string              `yaml:"syncs,omitempty"`
 }
 
 // EnvWith return list of environment variable definitions from project configs
 // with values appended to end of the list.
 func (p ProjectConfig) EnvWith(values []string) (result []string) {
 	result = append(result, p.Env...)
-	result = append(result, values...)
+
+	for _, value := range values {
+		if !model.IsValidEnvKeyValuePair(value) {
+			log.Fatalf("Invalid environment variable [%s], must be in format KEY=value. E.g. --env FOO=bar", value)
+		}
+		result = append(result, value)
+	}
 	return result
 }
 
 // ReadProjectConfig read ProjectConfig from given path
 // If file doesn't exist, returns empty config so it's safe for reading even
 // The file doesn't exist. In any other failure case, will fatal.
-func ReadProjectConfig(path string) (result *ProjectConfig) {
+func ReadProjectConfig(path string) *ProjectConfig {
 	// Defaults
 	config := &ProjectConfig{
 		path: path,
-		Sync: SyncConfig{
-			Image:  "docker.io/ernoaapa/rsync:1940a6c",
-			Target: "/volume",
+		SyncContainer: &containers.Container{
+			Name:  "sync",
+			Image: "docker.io/ernoaapa/rsync:ff1a0fa9bc12d051bae4300508d361cc65df338b",
+			Env: []string{
+				"USER=root",
+				"GROUP=root",
+			},
+		},
+		Syncs: []string{
+			".:/volume",
 		},
 	}
 
 	if !fs.FileExist(path) {
-		return config
+		return &ProjectConfig{}
 	}
 
 	data, err := ioutil.ReadFile(path)
@@ -60,4 +75,17 @@ func ReadProjectConfig(path string) (result *ProjectConfig) {
 	}
 
 	return config
+}
+
+// WriteProjectConfig writes project config in yaml format into given path
+func WriteProjectConfig(path string, config *ProjectConfig) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to marshal config to yaml format")
+	}
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		return errors.Wrapf(err, "Failed to write config to path [%s]", path)
+	}
+
+	return nil
 }

--- a/pkg/config/project_test.go
+++ b/pkg/config/project_test.go
@@ -22,7 +22,7 @@ image: someproject/foobar:latest
 
 	assert.Equal(t, "foobar", config.Name)
 	assert.Equal(t, "someproject/foobar:latest", config.Image)
-	assert.Equal(t, "docker.io/ernoaapa/rsync:1940a6c", config.Sync.Image, "sync.image should have default value")
+	assert.NotEmpty(t, config.SyncContainer.Image, "syncContainer.image should have default value")
 }
 
 func TestGetProjectSyncConfig(t *testing.T) {
@@ -32,8 +32,10 @@ func TestGetProjectSyncConfig(t *testing.T) {
 	writeErr := ioutil.WriteFile(file.Name(), []byte(`
 name: foobar
 image: someproject/foobar:latest
-sync:
+syncContainer:
   image: "myproject/custom:v1"
+syncs:
+    - out:/app
 `), 0644)
 	assert.NoError(t, writeErr, "Error while writing temp file")
 
@@ -41,5 +43,42 @@ sync:
 
 	assert.Equal(t, "foobar", config.Name)
 	assert.Equal(t, "someproject/foobar:latest", config.Image)
-	assert.Equal(t, "myproject/custom:v1", config.Sync.Image)
+	assert.Equal(t, "myproject/custom:v1", config.SyncContainer.Image)
+	assert.Equal(t, []string{"out:/app"}, config.Syncs)
+}
+
+func TestGetProjectMountConfig(t *testing.T) {
+	file, tempErr := ioutil.TempFile(os.TempDir(), "config-test")
+	assert.NoError(t, tempErr, "Failed to create temp file for test")
+	defer os.Remove(file.Name())
+	writeErr := ioutil.WriteFile(file.Name(), []byte(`
+name: foobar
+image: someproject/foobar:latest
+mounts:
+    - source=/dev,destination=/host-dev
+`), 0644)
+	assert.NoError(t, writeErr, "Error while writing temp file")
+
+	config := ReadProjectConfig(file.Name())
+
+	assert.Equal(t, "foobar", config.Name)
+	assert.Equal(t, "someproject/foobar:latest", config.Image)
+	assert.Equal(t, []string{"source=/dev,destination=/host-dev"}, config.Mounts)
+}
+
+func TestGetProjectCommand(t *testing.T) {
+	file, tempErr := ioutil.TempFile(os.TempDir(), "config-test")
+	assert.NoError(t, tempErr, "Failed to create temp file for test")
+	defer os.Remove(file.Name())
+	writeErr := ioutil.WriteFile(file.Name(), []byte(`
+name: foobar
+image: someproject/foobar:latest
+command: ["foo", "bar"]
+`), 0644)
+	assert.NoError(t, writeErr, "Error while writing temp file")
+
+	config := ReadProjectConfig(file.Name())
+
+	assert.Equal(t, "foobar", config.Name)
+	assert.Equal(t, []string{"foo", "bar"}, config.Command)
 }

--- a/pkg/sync/model.go
+++ b/pkg/sync/model.go
@@ -1,0 +1,7 @@
+package sync
+
+// Sync configurations
+type Sync struct {
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
+}

--- a/pkg/sync/rsync.go
+++ b/pkg/sync/rsync.go
@@ -1,18 +1,25 @@
 package sync
 
 import (
+	"fmt"
 	"os/exec"
+	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // StartRsync path to target rsync server on given interval
-func StartRsync(done <-chan struct{}, sourceDirs []string, destination string, interval time.Duration) {
+func StartRsync(done <-chan struct{}, host string, port int, syncs []Sync, interval time.Duration) {
 	go func() {
 		for {
 			select {
 			case <-time.After(interval):
-				for _, sourceDir := range sourceDirs {
-					executeRsync(sourceDir, destination)
+				for _, sync := range syncs {
+					err := executeRsync(sync.Source, fmt.Sprintf("rsync://%s:%d/%s/", host, port, strings.Replace(sync.Destination, "/", "_", -1)))
+					if err != nil {
+						log.Errorf("Error while running rsync: %s", err)
+					}
 				}
 			case <-done:
 				return
@@ -22,7 +29,7 @@ func StartRsync(done <-chan struct{}, sourceDirs []string, destination string, i
 }
 
 func executeRsync(sourceDir, destination string) error {
-	cmd := exec.Command("/usr/bin/rsync", "--recursive", "--perms", "--times", "--links", "--devices", "--specials", "--compress", sourceDir, destination)
-	// TODO: How to display sync completed /failed? Cannot print terminal because messing out terminal attachment
+	cmd := exec.Command("/usr/bin/rsync", "--recursive", "--times", "--links", "--devices", "--specials", "--compress", sourceDir, destination)
+	// TODO: How to display sync completed /failed? Cannot print terminal because messing out terminal attachment. Desktop notification?
 	return cmd.Run()
 }

--- a/pkg/sync/utils.go
+++ b/pkg/sync/utils.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+func MustParseAll(strings []string) (result []Sync) {
+	for _, str := range strings {
+		sync, err := Parse(str)
+		if err != nil {
+			log.Fatalf("Invalid formated sync [%s], must be in format: '<source>:<destination>', for example '~/local/dir:/data'", str)
+		}
+		result = append(result, sync)
+	}
+	return result
+}
+
+// Parse parses a sync string in the form "~/local/dir:/data"
+func Parse(str string) (Sync, error) {
+	parts := strings.Split(str, ":")
+
+	if len(parts) == 2 {
+		return Sync{
+			Source:      parts[0],
+			Destination: parts[1],
+		}, nil
+	}
+
+	return Sync{}, fmt.Errorf("Invalid formated sync [%s], must be in format: '<source>:<destination>', for example '~/local/dir:/data'", str)
+}

--- a/pkg/sync/utils_test.go
+++ b/pkg/sync/utils_test.go
@@ -1,0 +1,15 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	sync, err := Parse("~/local/dir:/data")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "~/local/dir", sync.Source)
+	assert.Equal(t, "/data", sync.Destination)
+}

--- a/pkg/utils/fqin.go
+++ b/pkg/utils/fqin.go
@@ -16,7 +16,7 @@ var (
 // E.g. eaapa/hello-world -> docker.io/eaapa/hello-world:latest
 func ExpandToFQIN(source string) string {
 	if source == "" {
-		log.Fatal("Empty image ref to expand FQIN (Fully Qualified Image Name")
+		log.Fatal("Trying to expand empty image ref to FQIN (Fully Qualified Image Name)")
 		return ""
 	}
 	registry := defaultRegistry


### PR DESCRIPTION
Refactored the `eli run` to follow same functionality with `docker run` and created new `eli up` command which starts development session in the device.