### PR TITLE
Support 'command' in .eliot.yml

### DIFF
--- a/cmd/eli/createCommand.go
+++ b/cmd/eli/createCommand.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ernoaapa/eliot/cmd"
 	pods "github.com/ernoaapa/eliot/pkg/api/services/pods/v1"
-	"github.com/ernoaapa/eliot/pkg/cmd/ui"
 	"github.com/ernoaapa/eliot/pkg/printers"
 	"github.com/ernoaapa/eliot/pkg/progress"
 	"github.com/ernoaapa/eliot/pkg/resolve"
@@ -48,29 +47,9 @@ var createCommand = cli.Command{
 		client := cmd.GetClient(config)
 
 		for _, pod := range pods {
-			lines := map[string]ui.Line{}
 			progressc := make(chan []*progress.ImageFetch)
+			go cmd.ShowDownloadProgress(progressc)
 
-			go func() {
-				for fetches := range progressc {
-					for _, fetch := range fetches {
-						if _, ok := lines[fetch.Image]; !ok {
-							lines[fetch.Image] = ui.NewLine().Loadingf("Download %s", fetch.Image)
-						}
-
-						if fetch.IsDone() {
-							if fetch.Failed {
-								lines[fetch.Image].Errorf("Failed %s", fetch.Image)
-							} else {
-								lines[fetch.Image].Donef("Downloaded %s", fetch.Image)
-							}
-						} else {
-							current, total := fetch.GetProgress()
-							lines[fetch.Image].WithProgress(current, total)
-						}
-					}
-				}
-			}()
 			err := client.CreatePod(progressc, pod)
 			close(progressc)
 			if err != nil {

--- a/cmd/eli/upCommand.go
+++ b/cmd/eli/upCommand.go
@@ -99,7 +99,7 @@ var upCommand = cli.Command{
 			syncs         = cmd.MustParseSyncs(append(projectConfig.Syncs, clicontext.StringSlice("sync")...))
 			mounts        = cmd.MustParseMounts(append(projectConfig.Mounts, clicontext.StringSlice("mount")...))
 			binds         = cmd.MustParseBinds(append(projectConfig.Binds, clicontext.StringSlice("bind")...))
-			args          = cmd.DropDoubleDash(clicontext.Args())
+			args          = append(projectConfig.Command, cmd.DropDoubleDash(clicontext.Args())...)
 
 			stdin  = os.Stdin
 			stdout = os.Stdout

--- a/cmd/progress.go
+++ b/cmd/progress.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	ui "github.com/ernoaapa/eliot/pkg/cmd/ui"
+	"github.com/ernoaapa/eliot/pkg/progress"
+)
+
+// ShowDownloadProgress prints UI "downloading" lines and updates until
+// the progress channel closes
+func ShowDownloadProgress(progressc <-chan []*progress.ImageFetch) {
+	lines := map[string]ui.Line{}
+	for fetches := range progressc {
+		for _, fetch := range fetches {
+			if _, ok := lines[fetch.Image]; !ok {
+				lines[fetch.Image] = ui.NewLine().Loadingf("Download %s", fetch.Image)
+			}
+
+			if fetch.IsDone() {
+				if fetch.Failed {
+					lines[fetch.Image].Errorf("Failed %s", fetch.Image)
+				} else {
+					lines[fetch.Image].Donef("Downloaded %s", fetch.Image)
+				}
+			} else {
+				current, total := fetch.GetProgress()
+				lines[fetch.Image].WithProgress(current, total)
+			}
+		}
+	}
+
+	for image, line := range lines {
+		line.Donef("Completed %s", image)
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -398,3 +398,22 @@ func ResolveContainerID(containers []*containers.ContainerStatus, containerName 
 		return "", fmt.Errorf("Pod contains %d containers, you must define container name", containerCount)
 	}
 }
+
+// FindRunningContainerID search from Pod definition a containerID by container name
+func FindRunningContainerID(pod *pods.Pod, name string) (string, error) {
+	if pod.Status != nil && len(pod.Status.ContainerStatuses) > 0 {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == name {
+				return status.ContainerID, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Cannot find ContainerID with name %s", name)
+}
+
+// StopCatch will close the given channel when receives Stop signal (^C)
+func StopCatch(sigc chan os.Signal) {
+	signal.Stop(sigc)
+	close(sigc)
+}


### PR DESCRIPTION
Added support to override /prefix command by defining `command` in the `.eliot.yml`.