### PR TITLE
Do not log warning if lifecycle extension not found from container

### DIFF
--- a/pkg/runtime/containerd/extensions/errors.go
+++ b/pkg/runtime/containerd/extensions/errors.go
@@ -1,0 +1,24 @@
+package extensions
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// Definitions of common error types from extensions
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+// IsNotFound returns true if the error is due to a missing resource
+func IsNotFound(err error) bool {
+	return errors.Cause(err) == ErrNotFound
+}
+
+// ErrWithMessagef updates error message with formated message
+// I.e. errors.WithMessage(err, fmt.Sprintf(...
+// Hopefully we can change to errors.WithMessagef some day: https://github.com/pkg/errors/pull/118
+func ErrWithMessagef(err error, format string, args ...interface{}) error {
+	return errors.WithMessage(err, fmt.Sprintf(format, args...))
+}

--- a/pkg/runtime/containerd/extensions/lifecycle.go
+++ b/pkg/runtime/containerd/extensions/lifecycle.go
@@ -77,7 +77,7 @@ func IncrementRestart(ctx context.Context, client *containerd.Client, c *contain
 func GetLifecycleExtension(c containers.Container) (ContainerLifecycle, error) {
 	extension, ok := c.Extensions[lifecycleExtensionName]
 	if !ok {
-		return ContainerLifecycle{}, fmt.Errorf("ContainerLifecycle extension not found in container [%s]", c.ID)
+		return ContainerLifecycle{}, ErrWithMessagef(ErrNotFound, "ContainerLifecycle extension not found in container [%s]", c.ID)
 	}
 
 	decoded, err := typeurl.UnmarshalAny(&extension)

--- a/pkg/runtime/containerd/extensions/lifecycle_test.go
+++ b/pkg/runtime/containerd/extensions/lifecycle_test.go
@@ -1,0 +1,30 @@
+package extensions
+
+import (
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/typeurl"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLifecycleExtension(t *testing.T) {
+	lifecycle := &ContainerLifecycle{
+		StartCount:    666,
+		RestartPolicy: OnFailure,
+	}
+	any, _ := typeurl.MarshalAny(lifecycle)
+	extensions := make(map[string]types.Any)
+	extensions[lifecycleExtensionName] = *any
+
+	result, err := GetLifecycleExtension(containers.Container{Extensions: extensions})
+	assert.NoError(t, err)
+	assert.Equal(t, lifecycle.StartCount, result.StartCount)
+	assert.Equal(t, lifecycle.RestartPolicy, result.RestartPolicy)
+}
+
+func TestGetLifecycleExtensionReturnNotFoundErr(t *testing.T) {
+	_, err := GetLifecycleExtension(containers.Container{})
+	assert.True(t, IsNotFound(err))
+}

--- a/pkg/runtime/containerd/mapping/containerd.go
+++ b/pkg/runtime/containerd/mapping/containerd.go
@@ -162,7 +162,7 @@ func MapContainerStatusToInternalModel(container containers.Container, status co
 
 func getRestartCount(container containers.Container) int {
 	lifecycle, err := extensions.GetLifecycleExtension(container)
-	if err != nil {
+	if err != nil && !extensions.IsNotFound(err) {
 		log.Warnf("Error while resolving container restart count, fallback to zero: %s", err)
 	}
 
@@ -189,7 +189,7 @@ func haveNamespace(container containers.Container, namespace specs.LinuxNamespac
 
 func getRestartPolicy(container containers.Container) string {
 	lifecycle, err := extensions.GetLifecycleExtension(container)
-	if err != nil {
+	if err != nil && !extensions.IsNotFound(err) {
 		log.Warnf("Error while resolving container restart policy, fallback to default: %s", err)
 	}
 


### PR DESCRIPTION
Otherwise we fill the log files really quickly.