### PR TITLE
Release 'eli' cli with same name through brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ archive:
   name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 brew:
+  name: eli
   github:
     owner: ernoaapa
     name: homebrew-eliot

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@
 Eliot client, called `eli`, is just a binary what you can download from [Eliot releases](https://github.com/ernoaapa/eliot/releases).
 
 ### MacOS
-1. `brew install ernoaapa/eliot/eliot`
+1. `brew install ernoaapa/eliot/eli`
 2. Test `eli --version`
 
 ### Linux


### PR DESCRIPTION
Previously the goreleaser -tool were releasing the 'eli' cli
with name 'eliot/eliot' in brew tab. Now goreleaser supports
custom name for the tab so now it's 'eliot/eli'.