### PR TITLE
 Updated containerd to v1.0.2 with fix "Fix pull-multi-arch images for Arm

### DIFF
--- a/pkg/runtime/containerd_test.go
+++ b/pkg/runtime/containerd_test.go
@@ -1,0 +1,18 @@
+package runtime
+
+import (
+	"testing"
+
+	imagespecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlatformExist(t *testing.T) {
+	assert.True(t, platformExist("linux/arm64", []imagespecs.Platform{
+		{OS: "linux", Architecture: "arm64"},
+	}))
+
+	assert.False(t, platformExist("linux/arm64", []imagespecs.Platform{
+		{OS: "linux", Architecture: "amd64"},
+	}))
+}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -11,6 +11,7 @@ import (
 var (
 	ErrNotFound      = errors.New("not found")
 	ErrAlreadyExists = errors.New("already exists")
+	ErrNotSupported  = errors.New("not supported")
 )
 
 // IsNotFound returns true if the error is due to a missing resource

--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/urfave/cli v1.20.0
 github.com/stretchr/testify v1.1.4
 github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
-github.com/containerd/containerd 83cf37155670575ec0782bb7940b53876c151c40
+github.com/containerd/containerd v1.0.2+patch-1 https://github.com/ernoaapa/containerd.git
 github.com/sirupsen/logrus v1.0.3
 golang.org/x/crypto 81e90905daefcd6fd217b62423c0908922eadb30
 golang.org/x/sys bb24a47a89eac6c1227fbcb2ae37a8b9ed323366

--- a/vendor/github.com/containerd/containerd/platforms/cpuinfo.go
+++ b/vendor/github.com/containerd/containerd/platforms/cpuinfo.go
@@ -1,0 +1,85 @@
+package platforms
+
+import (
+	"bufio"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+)
+
+// Present the ARM instruction set architecture, eg: v7, v8
+var cpuVariant string
+
+func init() {
+	if isArmArch(runtime.GOARCH) {
+		cpuVariant = getCPUVariant()
+	} else {
+		cpuVariant = ""
+	}
+}
+
+// For Linux, the kernel has already detected the ABI, ISA and Features.
+// So we don't need to access the ARM registers to detect platform information
+// by ourselves. We can just parse these information from /proc/cpuinfo
+func getCPUInfo(pattern string) (info string, err error) {
+	if !isLinuxOS(runtime.GOOS) {
+		return "", errors.Wrapf(errdefs.ErrNotImplemented, "getCPUInfo for OS %s", runtime.GOOS)
+	}
+
+	cpuinfo, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return "", err
+	}
+	defer cpuinfo.Close()
+
+	// Start to Parse the Cpuinfo line by line. For SMP SoC, we parse
+	// the first core is enough.
+	scanner := bufio.NewScanner(cpuinfo)
+	for scanner.Scan() {
+		newline := scanner.Text()
+		list := strings.Split(newline, ":")
+
+		if len(list) > 1 && strings.EqualFold(strings.TrimSpace(list[0]), pattern) {
+			return strings.TrimSpace(list[1]), nil
+		}
+	}
+
+	// Check whether the scanner encountered errors
+	err = scanner.Err()
+	if err != nil {
+		return "", err
+	}
+
+	return "", errors.Wrapf(errdefs.ErrNotFound, "getCPUInfo for pattern: %s", pattern)
+}
+
+func getCPUVariant() string {
+	variant, err := getCPUInfo("Cpu architecture")
+	if err != nil {
+		log.L.WithError(err).Error("failure getting variant")
+		return ""
+	}
+
+	switch variant {
+	case "8":
+		variant = "v8"
+	case "7", "7M", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
+		variant = "v7"
+	case "6", "6TEJ":
+		variant = "v6"
+	case "5", "5T", "5TE", "5TEJ":
+		variant = "v5"
+	case "4", "4T":
+		variant = "v4"
+	case "3":
+		variant = "v3"
+	default:
+		variant = "unknown"
+	}
+
+	return variant
+}

--- a/vendor/github.com/containerd/containerd/platforms/database.go
+++ b/vendor/github.com/containerd/containerd/platforms/database.go
@@ -5,6 +5,13 @@ import (
 	"strings"
 )
 
+// isLinuxOS returns true if the operating system is Linux.
+//
+// The OS value should be normalized before calling this function.
+func isLinuxOS(os string) bool {
+	return os == "linux"
+}
+
 // These function are generated from from https://golang.org/src/go/build/syslist.go.
 //
 // We use switch statements because they are slightly faster than map lookups
@@ -16,6 +23,17 @@ import (
 func isKnownOS(os string) bool {
 	switch os {
 	case "android", "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
+		return true
+	}
+	return false
+}
+
+// isArmArch returns true if the architecture is ARM.
+//
+// The arch value should be normalized before being passed to this function.
+func isArmArch(arch string) bool {
+	switch arch {
+	case "arm", "arm64":
 		return true
 	}
 	return false

--- a/vendor/github.com/containerd/containerd/platforms/defaults.go
+++ b/vendor/github.com/containerd/containerd/platforms/defaults.go
@@ -16,6 +16,7 @@ func DefaultSpec() specs.Platform {
 	return specs.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
-		// TODO(stevvooe): Need to resolve GOARM for arm hosts.
+		// The Variant field will be empty if arch != ARM.
+		Variant: cpuVariant,
 	}
 }


### PR DESCRIPTION
We want to start follow stable releases of containerd, but there's
one fix containerd/containerd#1575 which
prevents pulling images on ARM.
Switched to use custom containerd version which is
v1.0.2 with Weichen81:arm-multi-arch fix.