### PR TITLE
Fix discovery server not stopping properly

### DIFF
--- a/pkg/discovery/client_test.go
+++ b/pkg/discovery/client_test.go
@@ -1,0 +1,20 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientNodes(t *testing.T) {
+	server := NewServer("testing", 1234, "v1.0")
+	go server.Serve()
+	defer server.Stop()
+
+	nodes, err := Nodes(1 * time.Second)
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 1)
+	assert.Equal(t, int64(1234), nodes[0].GrpcPort)
+	assert.Equal(t, "v1.0", nodes[0].Version)
+}

--- a/pkg/discovery/server.go
+++ b/pkg/discovery/server.go
@@ -20,10 +20,11 @@ type Server struct {
 // NewServer creates new discovery server
 func NewServer(name string, port int, version string) *Server {
 	return &Server{
-		Name:    name,
-		Domain:  "local.",
-		Port:    port,
-		Version: version,
+		Name:     name,
+		Domain:   "local.",
+		Port:     port,
+		Version:  version,
+		shutdown: make(chan bool),
 	}
 }
 

--- a/pkg/discovery/server_test.go
+++ b/pkg/discovery/server_test.go
@@ -1,0 +1,19 @@
+package discovery
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestServerServeStop(t *testing.T) {
+	var wg sync.WaitGroup
+	server := NewServer("testing", 1234, "v1.0")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.Serve()
+	}()
+
+	server.Stop()
+	wg.Wait()
+}


### PR DESCRIPTION
Previously discovery.Server hang if Stop() were called and never actually close. There were missing make(chan).