### PR TITLE
Resolve project image to manifest images

### DIFF
--- a/build/install-build-tools.sh
+++ b/build/install-build-tools.sh
@@ -2,20 +2,19 @@
 
 set -eu
 
+echo "GOPATH: $GOPATH"
+
+rm -rf $GOPATH/src/github.com/goreleaser/nfpm
+
 go get -u github.com/goreleaser/goreleaser
-# Switch to fixed fork
-cd $GOPATH/src/github.com/goreleaser/goreleaser
-git remote add ernoaapa https://github.com/ernoaapa/goreleaser.git || true
-git fetch ernoaapa
-git checkout fix-arm-architecture
-GOBIN=$GOPATH/bin go install .
 
 go get -u github.com/goreleaser/nfpm
 # Switch to fixed fork
 cd $GOPATH/src/github.com/goreleaser/nfpm
 git remote add ernoaapa https://github.com/ernoaapa/nfpm.git || true
 git fetch ernoaapa
-git checkout fix-arm-architecture
+git checkout ernoaapa/fix-arm-architecture
+go get ./...
 GOBIN=$GOPATH/bin go install ./cmd/nfpm/
 
 go get github.com/estesp/manifest-tool

--- a/cmd/eli/createPodCommand.go
+++ b/cmd/eli/createPodCommand.go
@@ -20,7 +20,7 @@ var createPodCommand = cli.Command{
 	UsageText: `eli create pod [options] <NAME>
 
 	 # Create new pod 'my-pod' and create single container
-	 eli create pod --image docker.io/arm64v8/alpine:latest my-pod
+	 eli create pod --image alpine my-pod
 `,
 	Flags: []cli.Flag{
 		cli.StringSliceFlag{

--- a/cmd/eli/runCommand.go
+++ b/cmd/eli/runCommand.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ernoaapa/eliot/pkg/cmd/ui"
 	"github.com/ernoaapa/eliot/pkg/model"
 	"github.com/ernoaapa/eliot/pkg/progress"
-	"github.com/ernoaapa/eliot/pkg/resolve"
 	"github.com/ernoaapa/eliot/pkg/term"
 	"github.com/ernoaapa/eliot/pkg/utils"
 	"github.com/pkg/errors"
@@ -68,7 +67,7 @@ var runCommand = cli.Command{
 	Action: func(clicontext *cli.Context) (err error) {
 		var (
 			name    = clicontext.String("name")
-			image   = clicontext.Args().First()
+			image   = utils.ExpandToFQIN(clicontext.Args().First())
 			rm      = clicontext.Bool("rm")
 			tty     = clicontext.Bool("tty")
 			env     = clicontext.StringSlice("env")
@@ -88,23 +87,6 @@ var runCommand = cli.Command{
 
 		conf := cmd.GetConfigProvider(clicontext)
 		client := cmd.GetClient(conf)
-
-		if image == "" {
-			uiline := ui.NewLine().Loading("Resolve image for the project...")
-			info, err := client.GetInfo()
-			if err != nil {
-				uiline.Fatalf("Unable to resolve image for the project. Failed to get target node architecture: %s", err)
-			}
-
-			var projectType string
-			projectType, image, err = resolve.Image(info.Arch, cmd.GetCurrentDirectory())
-			if err != nil {
-				uiline.Fatal("Unable to automatically resolve image for the project. You must define target container image with --image option")
-			}
-			uiline.Donef("Detected %s project, use image: %s (arch %s)", projectType, image, info.Arch)
-		}
-
-		image = utils.ExpandToFQIN(image)
 
 		if name == "" {
 			// Default to current directory name

--- a/cmd/eli/upCommand.go
+++ b/cmd/eli/upCommand.go
@@ -115,17 +115,13 @@ var upCommand = cli.Command{
 
 		if image == "" {
 			log := ui.NewLine().Loading("Resolve image for the project...")
-			info, err := client.GetInfo()
-			if err != nil {
-				log.Fatalf("Unable to resolve image for the project. Failed to get target node architecture: %s", err)
-			}
 
 			var projectType string
-			projectType, image, err = resolve.Image(info.Arch, cmd.GetCurrentDirectory())
+			projectType, image, err = resolve.Image(cmd.GetCurrentDirectory())
 			if err != nil {
 				log.Fatal("Unable to automatically resolve image for the project. You must define target container image with --image option")
 			}
-			log.Donef("Detected %s project, use image: %s (arch %s)", projectType, image, info.Arch)
+			log.Donef("Detected %s project, use image: %s", projectType, image)
 		}
 
 		image = utils.ExpandToFQIN(image)

--- a/docs/client.md
+++ b/docs/client.md
@@ -26,7 +26,7 @@ With `run` command you can quickly run some container in the device, and after y
 
 ```shell
 **[terminal]
-**[prompt ernoaapa@mac]**[path ~/go/src/github.com/ernoaapa/eliot]**[delimiter  $ ]**[command eli run docker.io/arm64v8/alpine:latest -- /bin/sh]
+**[prompt ernoaapa@mac]**[path ~/go/src/github.com/ernoaapa/eliot]**[delimiter  $ ]**[command eli run alpine -- /bin/sh]
 root@linuxkit-96165e7f48d7:/# uname -a
 Linux raspberrypi-e2ccbe63f23d 4.9.72-linuxkit #1 SMP Thu Dec 28 19:08:26 UTC 2017 x86_64 Linux
 root@linuxkit-96165e7f48d7:/# exit
@@ -124,10 +124,10 @@ Sometimes you want to create a _Pod_ and making [yaml specification](configurati
 
 ```shell
 **[terminal]
-**[prompt ernoaapa@mac]**[path ~]**[delimiter  $ ]**[command eli create pod --image docker.io/arm64v8/alpine:latest testing]
+**[prompt ernoaapa@mac]**[path ~]**[delimiter  $ ]**[command eli create pod --image alpine testing]
   ✓ Discovered 1 device(s) from network
   • Connect to linuxkit-96165e7f48d7.local. (192.168.64.79:5000)
-  ⠸ Download docker.io/arm64v8/alpine:latest
+  ⠸ Download docker.io/library/alpine:latest
 Name:             testing
 Namespace:        eliot
 Device:           linuxkit-96165e7f48d7
@@ -136,8 +136,8 @@ Restart Policy:   always
 Host Network:     false
 Host PID:         false
 Containers:
-          arm64v8-alpine:
-                    Image:           docker.io/arm64v8/alpine:latest
+          library-alpine:
+                    Image:           docker.io/library/alpine:latest
                     ContainerID:     b97cq4r744405e9hmscg
                     State:           running
                     Restart Count:   0

--- a/pkg/resolve/image.go
+++ b/pkg/resolve/image.go
@@ -11,34 +11,13 @@ import (
 )
 
 // Image try to resolve what container image should be used to run project in the directory
-func Image(arch string, projectDir string) (projectType, image string, err error) {
+func Image(projectDir string) (projectType, image string, err error) {
 	if isNodeProject(projectDir) {
-		switch arch {
-		case "amd64":
-			return "nodejs", "docker.io/library/node:latest", nil
-		case "arm64":
-			return "nodejs", "docker.io/arm64v8/node:latest", nil
-		default:
-			return "", "", fmt.Errorf("Unsupported NodeJS project in architecture [%s]", arch)
-		}
+		return "node", "docker.io/library/node:latest", nil
 	} else if isGolangProject(projectDir) {
-		switch arch {
-		case "amd64":
-			return "golang", "docker.io/library/golang:latest", nil
-		case "arm64":
-			return "golang", "docker.io/arm64v8/golang:latest", nil
-		default:
-			return "", "", fmt.Errorf("Unsupported Golang project in architecture [%s]", arch)
-		}
+		return "golang", "docker.io/library/golang:latest", nil
 	} else if isPythonProject(projectDir) {
-		switch arch {
-		case "amd64":
-			return "python", "docker.io/library/python:latest", nil
-		case "arm64":
-			return "python", "docker.io/arm64v8/python:latest", nil
-		default:
-			return "", "", fmt.Errorf("Unsupported Golang project in architecture [%s]", arch)
-		}
+		return "python", "docker.io/library/python:latest", nil
 	}
 
 	return "", "", fmt.Errorf("Unable to resolve container image for project in directory [%s]", projectDir)

--- a/pkg/resolve/image_test.go
+++ b/pkg/resolve/image_test.go
@@ -1,7 +1,6 @@
 package resolve
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -12,30 +11,24 @@ import (
 var targetArchitectures = []string{"amd64", "arm64"}
 
 func TestImageResolveNode(t *testing.T) {
-	projectDir := getExampleDirectory("node")
-
-	testResolving(t, projectDir, "nodejs", map[string]string{
-		"amd64": "docker.io/library/node:latest",
-		"arm64": "docker.io/arm64v8/node:latest",
-	})
+	projectType, image, err := Image(getExampleDirectory("node"))
+	assert.NoError(t, err)
+	assert.Equal(t, "node", projectType)
+	assert.Equal(t, "docker.io/library/node:latest", image)
 }
 
 func TestImageResolveGolang(t *testing.T) {
-	projectDir := getExampleDirectory("golang")
-
-	testResolving(t, projectDir, "golang", map[string]string{
-		"amd64": "docker.io/library/golang:latest",
-		"arm64": "docker.io/arm64v8/golang:latest",
-	})
+	projectType, image, err := Image(getExampleDirectory("golang"))
+	assert.NoError(t, err)
+	assert.Equal(t, "golang", projectType)
+	assert.Equal(t, "docker.io/library/golang:latest", image)
 }
 
 func TestImageResolvePython(t *testing.T) {
-	projectDir := getExampleDirectory("python")
-
-	testResolving(t, projectDir, "python", map[string]string{
-		"amd64": "docker.io/library/python:latest",
-		"arm64": "docker.io/arm64v8/python:latest",
-	})
+	projectType, image, err := Image(getExampleDirectory("python"))
+	assert.NoError(t, err)
+	assert.Equal(t, "python", projectType)
+	assert.Equal(t, "docker.io/library/python:latest", image)
 }
 
 func getExampleDirectory(name string) string {
@@ -44,18 +37,4 @@ func getExampleDirectory(name string) string {
 		log.Fatal(err)
 	}
 	return dir
-}
-
-func testResolving(t *testing.T, projectDir, expectedProjectType string, images map[string]string) {
-	for _, arch := range targetArchitectures {
-		expectedImage, ok := images[arch]
-		if !ok {
-			assert.FailNow(t, fmt.Sprintf("Test case is missing expected image for projectType %s and architecture %s", expectedProjectType, arch))
-		}
-
-		projectType, image, err := Image(arch, projectDir)
-		assert.NoError(t, err)
-		assert.Equal(t, expectedProjectType, projectType)
-		assert.Equal(t, expectedImage, image)
-	}
 }


### PR DESCRIPTION
Previously we were using the non-manifest images like
'docker.io/arm64v8/node:latest' when we were resolving project
images automatically.
Nowadays the 'docker.io/library/node:latest' is manifest image
which supports multiple different architectures so we don't
need to handle all the cases by ourself.